### PR TITLE
Update .dockerignore to manage SendHub.Web and SendHub.Daemon

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,8 +12,8 @@
 !src/SendHub.Features/**
 !src/SendHub.Infrastructure/
 !src/SendHub.Infrastructure/**
-!src/SendHub.Daemon/
-!src/SendHub.Daemon/**
+!src/SendHub.Web/
+!src/SendHub.Web/**
 
 # Exclude build artifacts within allowed trees
 src/SendHub/bin/
@@ -22,8 +22,8 @@ src/SendHub.Features/bin/
 src/SendHub.Features/obj/
 src/SendHub.Infrastructure/bin/
 src/SendHub.Infrastructure/obj/
-src/SendHub.Daemon/bin/
-src/SendHub.Daemon/obj/
+src/SendHub.Web/bin/
+src/SendHub.Web/obj/
 
 # Exclude environment-specific settings that may contain secrets
-src/SendHub.Daemon/appsettings.Development.json
+src/SendHub.Web/appsettings.Development.json


### PR DESCRIPTION
This pull request updates the `.dockerignore` file to remove references to the `SendHub.Daemon` project and add references to the `SendHub.Web` project. This ensures that Docker will now include the `SendHub.Web` source and configuration files as needed, and ignore the corresponding build artifacts and development settings for the web project instead of the daemon.

Most important changes:

**Docker ignore configuration updates:**

* Removed `src/SendHub.Daemon/` and related patterns, and added `src/SendHub.Web/` and related patterns to control which source files and directories are included in Docker builds.
* Updated build artifact and environment-specific file exclusions to target `SendHub.Web` instead of `SendHub.Daemon` (e.g., `bin/`, `obj/`, and `appsettings.Development.json`).