### PR TITLE
Update Dockerfile and .dockerignore for Aspire.ServiceDefaults

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,8 @@
 !src/SendHub.Infrastructure/**
 !src/SendHub.Web/
 !src/SendHub.Web/**
+!src/Aspire/SendHub.ServiceDefaults/
+!src/Aspire/SendHub.ServiceDefaults/**
 
 # Exclude build artifacts within allowed trees
 src/SendHub/bin/
@@ -24,6 +26,8 @@ src/SendHub.Infrastructure/bin/
 src/SendHub.Infrastructure/obj/
 src/SendHub.Web/bin/
 src/SendHub.Web/obj/
+src/Aspire/SendHub.ServiceDefaults/bin/
+src/Aspire/SendHub.ServiceDefaults/obj/
 
 # Exclude environment-specific settings that may contain secrets
 src/SendHub.Web/appsettings.Development.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,22 @@ COPY Directory.Build.props ./
 COPY Directory.Packages.props ./
 COPY SendHub.slnx ./
 
-COPY src/SendHub/SendHub.csproj                               src/SendHub/
-COPY src/SendHub.Features/SendHub.Features.csproj             src/SendHub.Features/
-COPY src/SendHub.Infrastructure/SendHub.Infrastructure.csproj src/SendHub.Infrastructure/
-COPY src/SendHub.Web/SendHub.Web.csproj                       src/SendHub.Web/
+COPY src/SendHub/SendHub.csproj                                                 src/SendHub/
+COPY src/SendHub.Features/SendHub.Features.csproj                               src/SendHub.Features/
+COPY src/SendHub.Infrastructure/SendHub.Infrastructure.csproj                   src/SendHub.Infrastructure/
+COPY src/SendHub.Web/SendHub.Web.csproj                                         src/SendHub.Web/
+COPY src/Aspire/SendHub.ServiceDefaults/SendHub.ServiceDefaults.csproj          src/Aspire/SendHub.ServiceDefaults/
 
 RUN dotnet restore src/SendHub.Web/SendHub.Web.csproj
 
 
 FROM restore AS build
 
-COPY src/SendHub/                src/SendHub/
-COPY src/SendHub.Features/       src/SendHub.Features/
-COPY src/SendHub.Infrastructure/ src/SendHub.Infrastructure/
-COPY src/SendHub.Web/            src/SendHub.Web/
+COPY src/SendHub/                              src/SendHub/
+COPY src/SendHub.Features/                     src/SendHub.Features/
+COPY src/SendHub.Infrastructure/               src/SendHub.Infrastructure/
+COPY src/SendHub.Web/                          src/SendHub.Web/
+COPY src/Aspire/SendHub.ServiceDefaults/       src/Aspire/SendHub.ServiceDefaults/
 
 RUN dotnet publish src/SendHub.Web/SendHub.Web.csproj \
     --configuration Release \


### PR DESCRIPTION
This pull request updates the Docker configuration and ignore rules to include the new `SendHub.ServiceDefaults` project in the build process. The changes ensure that the project is copied and restored during Docker builds, while also properly excluding its build artifacts.

**Docker build integration:**

* Added `COPY` statements for `src/Aspire/SendHub.ServiceDefaults/SendHub.ServiceDefaults.csproj` and the full `src/Aspire/SendHub.ServiceDefaults/` directory to the `Dockerfile`, ensuring the new project is included in the Docker build and publish steps. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R13) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R24)

**Docker ignore rules:**

* Updated `.dockerignore` to allow inclusion of `src/Aspire/SendHub.ServiceDefaults/` and its contents, while excluding its `bin/` and `obj/` directories to prevent build artifacts from being copied into the Docker context. [[1]](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R17-R18) [[2]](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R29-R30)